### PR TITLE
Relax version of react-transition-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^16.3.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1",
-    "react-transition-group": "^2.3.0"
+    "react-transition-group": ">=2.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.42",


### PR DESCRIPTION
We can relax version of `react-transition-group` in `peerDependencies`. I didn't find any breaking changes which block us to do it.